### PR TITLE
Add default PR reviewers in CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+## Default code reviewrs for all opened PRs
+* @LeonardoBerlatto
+* @GiovanniFrozza
+* @HBO1705
+* @lucaslgm


### PR DESCRIPTION
Esse arquivo adiciona automaticamente os membros do grupo como revisores em todo PR aberto 